### PR TITLE
Make cssVars optional

### DIFF
--- a/packages/multisite/lib/templates/plugin.js
+++ b/packages/multisite/lib/templates/plugin.js
@@ -70,20 +70,22 @@ export default (ctx, inject) => {
   multisiteOptions.site = currentSite;
 
   // CSS vars
-  const getComputedCssVars = (cssVars) => {
-    const style = Object.keys(cssVars).map(key => `${key}:${cssVars[key]}`);
-    return `:root{${style.join(';')}}`;
-  };
-  const headStyle = {
-    id: CSS_VARS_STYLE_ID,
-    type: 'text/css',
-    innerHTML: getComputedCssVars(currentSite.cssVars),
-  };
-  const styleIndex = ctx.app.head.style.findIndex(style => style.id === CSS_VARS_STYLE_ID);
-  if (styleIndex !== -1) {
-    ctx.app.head.style[styleIndex] = headStyle;
-  } else {
-    ctx.app.head.style.push(headStyle);
+  if (typeof currentSite.cssVars !== 'undefined') {
+    const getComputedCssVars = (cssVars) => {
+      const style = Object.keys(cssVars).map(key => `${key}:${cssVars[key]}`);
+      return `:root{${style.join(';')}}`;
+    };
+    const headStyle = {
+      id: CSS_VARS_STYLE_ID,
+      type: 'text/css',
+      innerHTML: getComputedCssVars(currentSite.cssVars),
+    };
+    const styleIndex = ctx.app.head.style.findIndex(style => style.id === CSS_VARS_STYLE_ID);
+    if (styleIndex !== -1) {
+      ctx.app.head.style[styleIndex] = headStyle;
+    } else {
+      ctx.app.head.style.push(headStyle);
+    }
   }
 
   // Meta


### PR DESCRIPTION
Great work on this module. I don't need to define CSS vars in my application, so it would be nice to make this optional. This PR wraps the CSS var setup in a condition similar to how meta is handled below, so you can omit `cssVars` from multisite config instead of having to pass an empty object.