### PR TITLE
T6250 - Revert previous commits from gpt-ads

### DIFF
--- a/packages/gpt-ads/package.json
+++ b/packages/gpt-ads/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-jest": "22.3.0",
     "eslint-plugin-vue": "5.2.1",
     "jest": "24.1.0",
-    "jsdom": "15.0.0",
+    "jsdom": "14.0.0",
     "nuxt": "2.4.3",
     "request-promise-native": "1.0.5",
     "standard-version": "latest"


### PR DESCRIPTION
Restarting activity on these modules. 

For now, removing previous commit to enable lerna publish for other packages without affecting `gpt-ads-model`